### PR TITLE
Add ability to generate tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,11 @@ var EslintValidationFilter = function(inputTree, options, internalOptions) {
         configFile: options.config || './node_modules/eslint/conf/eslint.json',
         rulePaths: options.rulesdir ? [options.rulesdir] : []
     });
+
+    this.testGenerator = options.testGenerator;
+    if (this.testGenerator) {
+      this.targetExtension = 'eslint-test.js';
+    }
 };
 
 module.exports = EslintValidationFilter;
@@ -82,6 +87,10 @@ EslintValidationFilter.prototype.processString = function (content, relativePath
             // throw error if severe messages exist
             throw 'severe rule errors';
         }
+    }
+
+    if (this.testGenerator) {
+      return this.testGenerator(relativePath, result);
     }
 
     // return unmodified string


### PR DESCRIPTION
This would allow us to generate failing tests. Follows the same approach as broccoli-jshint and broccoli-jscs. I have an ember-cli-eslint PR ready to make use of this if it gets in. It will also be a bug fix because returning the entire tree from `lintTree` currently results in the entire (non-processed) app and tests code to be duplicated in the `/tests/` directory. Ember Cli merges the returned tree from `lintTree` with the `tests` directory. So we should either return an empty tree, or return tests.

```javascript
var testTree = eslint(tree, {
  testGenerator: testGenerator
});

function testGenerator(path, results) {
  // Return failing test if results.length > 0
  // otherwise return passing test. 
}
```