### PR TITLE
Update eslint to ^0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/jonathanKingston/broccoli-lint-eslint",
   "dependencies": {
     "broccoli-filter": "^0.1.12",
-    "eslint": "^0.18.0"
+    "eslint": "^0.19.0"
   },
   "devDependencies": {
     "broccoli": "^0.15.3",


### PR DESCRIPTION
This seems to fix a default value parameters issue I encountered combined with eslint-babel