### PR TITLE
Upgrade to eslint@2.2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,13 @@
     "no-console": 0,
     "prefer-arrow-callback": 0,
     "prefer-reflect": 0,
-    "prefer-template": 0
+    "prefer-template": 0,
+    "no-restricted-syntax": [2, "WithStatement"],
+    "no-empty-label": 0,
+    "no-labels": 2,
+    "space-after-keywords": 0,
+    "space-before-keywords": 0,
+    "space-return-throw-case": 0,
+    "keyword-spacing": 2
   }
 }

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var eslint = require('./lib/index');
 var mergeTrees = require('broccoli-merge-trees');
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# develop
+- Update to eslint@2.2.0
+
 # 1.1.1
 - Update to eslint@1.4.1
 

--- a/conf/rules/no-alert.js
+++ b/conf/rules/no-alert.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function noAlerts(context) {
   return {
     CallExpression: function callExpression(node) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,7 @@
+/* eslint global-require: 0, consistent-return: 0 */
+
+'use strict';
+
 var Filter = require('broccoli-filter');
 var CLIEngine = require('eslint').CLIEngine;
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "rm -rf build/ && npm run lint && broccoli build build > broccoli-build.out && node node_modules/mocha/bin/mocha build/test.js"
+    "test": "rm -rf build/ && npm run lint && ./node_modules/broccoli-cli/bin/broccoli build build > broccoli-build.out && node node_modules/mocha/bin/mocha build/test.js"
   },
   "repository": {
     "type": "git",
@@ -29,11 +29,12 @@
   "homepage": "https://github.com/jonathanKingston/broccoli-lint-eslint",
   "dependencies": {
     "broccoli-filter": "^0.1.12",
-    "eslint": "^1.4.1"
+    "eslint": "^2.2.0"
   },
   "devDependencies": {
-    "broccoli": "^0.16.2",
-    "broccoli-merge-trees": "^0.2.1",
+    "broccoli": "^0.16.9",
+    "broccoli-cli": "^1.0.0",
+    "broccoli-merge-trees": "^1.1.1",
     "eslint-config-nightmare-mode": "^0.2.0",
     "mocha": "^2.2.4",
     "rimraf": "^2.3.2"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,7 +2,14 @@
   "extends": "nightmare-mode/node",
   "rules": {
     "no-console": 0,
-    "prefer-arrow-callback": 0
+    "prefer-arrow-callback": 0,
+    "no-empty-label": 0,
+    "no-labels": 2,
+    "no-restricted-syntax": [2, "WithStatement"],
+    "space-after-keywords": 0,
+    "space-before-keywords": 0,
+    "space-return-throw-case": 0,
+    "keyword-spacing": 2
   },
   "env": {
     "mocha": true

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+'use strict';
 var assert = require('assert');
 var fs = require('fs');
 var rimraf = require('rimraf');


### PR DESCRIPTION
https://github.com/jonathanKingston/broccoli-lint-eslint/issues/8

This is a bit messier than I'd like, as the upstream `nightmare-mode` eshint configs are designed for pre-2 eslint.

I'm also not quite sure how to test this standalone beyond the tests run by `npm test`, as I'm primarily an ember-cli user.