### PR TITLE
Platform-independent path-handling; more robust null-checking.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 /* eslint global-require: 0, consistent-return: 0 */
 
+const path = require('path');
+
 const Filter = require('broccoli-filter');
 const CLIEngine = require('eslint').CLIEngine;
 
@@ -102,11 +104,12 @@ EslintValidationFilter.prototype.write = function write(readTree, destDir) {
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content
-  const result = this.cli.executeOnFiles([this.eslintrc + '/' + relativePath]);
+  const result = this.cli.executeOnFiles([path.join(this.eslintrc, relativePath)]);
   const filteredResults = filterAllIgnoredFileMessages(result);
 
   // if verification has result
-  if (filteredResults.results[0].messages.length) {
+  if (filteredResults.results.length &&
+      filteredResults.results[0].messages.length) {
 
     // log formatter output
     console.log(this.formatter(filteredResults.results));
@@ -120,7 +123,13 @@ EslintValidationFilter.prototype.processString = function processString(content,
   }
 
   if (this.testGenerator) {
-    return this.testGenerator(relativePath, filteredResults.results[0].messages || []);
+    let messages = [];
+
+    if (filteredResults.results.length) {
+      messages = filteredResults.results[0].messages || [];
+    }
+
+    return this.testGenerator(relativePath, messages);
   }
 
   // return unmodified string


### PR DESCRIPTION
- Make all paths use `path.join()` instead of hard-coding
    slashes, so paths work correctly on Windows.
  - No longer *error* in the case that `filteredResults` items have no
    items in the `results` array; just return instead.

Fixes #15.