### PR TITLE
Use broccoli-persistent-filter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "nightmare-mode/node",
   "rules": {
+    "arrow-body-style": [2, "as-needed"],
     "arrow-parens": [2, "always"],
     "no-console": 0,
     "prefer-arrow-callback": 0,

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,14 +138,19 @@ EslintValidationFilter.prototype.baseDir = function baseDir() {
 };
 
 EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProcessString(content, relativePath) {
-  return md5Hex([content, relativePath, stringify(this.options, {
-    replacer(key, value) {
-      if (typeof value === 'function') {
-        return value.toString();
-      }
-      return value;
+  function functionStringifier(key, value) {
+    if (typeof value === 'function') {
+      return value.toString();
     }
-  })]);
+    return value;
+  }
+
+  return md5Hex([
+    content,
+    relativePath,
+    stringify(this.options, {replacer: functionStringifier}),
+    stringify(this.cli.getConfigForFile(path.join(this.eslintrc, relativePath)))
+  ]);
 };
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,12 @@
 /* eslint global-require: 0, consistent-return: 0 */
 
-const Filter = require('broccoli-filter');
+const Filter = require('broccoli-persistent-filter');
 const CLIEngine = require('eslint').CLIEngine;
+const md5Hex = require('md5-hex');
+const stringify = require('json-stable-stringify');
 const path = require('path');
+const BUILD_DIR_REGEX = new RegExp('(' + path.sep + ')?build(' + path.sep + ')?$');
+
 
 /**
  * Calculates the severity of a eslint.linter.verify result
@@ -88,16 +92,22 @@ function EslintValidationFilter(inputNode, options) {
   if (!(this instanceof EslintValidationFilter)) {
     return new EslintValidationFilter(inputNode, options);
   }
+
   this.options = options || {};
-  this.eslintOptions = options.options || {};
+  const eslintOptions = this.options.options || {};
 
   // default ignore:true option
-  if (typeof this.eslintOptions.ignore === 'undefined') {
-    this.eslintOptions.ignore = true;
+  if (typeof eslintOptions.ignore === 'undefined') {
+    eslintOptions.ignore = true;
+  }
+
+  // default is to persist filter output
+  if (typeof this.options.persist === 'undefined') {
+    this.options.persist = true;
   }
 
   // call base class constructor
-  Filter.call(this, inputNode);
+  Filter.call(this, inputNode, this.options);
 
   // set formatter
   if (typeof this.options.format === 'function') {
@@ -107,11 +117,11 @@ function EslintValidationFilter(inputNode, options) {
     this.formatter = require(this.options.format || 'eslint/lib/formatters/stylish');
   }
 
-  this.cli = new CLIEngine(this.eslintOptions);
+  this.cli = new CLIEngine(eslintOptions);
 
   this.eslintrc = resolveInputDirectory(inputNode);
 
-  this.testGenerator = options.testGenerator;
+  this.testGenerator = this.options.testGenerator;
   if (this.testGenerator) {
     this.targetExtension = 'lint-test.js';
   }
@@ -123,28 +133,30 @@ EslintValidationFilter.prototype.constructor = EslintValidationFilter;
 EslintValidationFilter.prototype.extensions = ['js'];
 EslintValidationFilter.prototype.targetExtension = 'js';
 
-EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
-  'use strict'; // eslint-disable-line strict
+EslintValidationFilter.prototype.baseDir = function baseDir() {
+  return __dirname.replace(BUILD_DIR_REGEX, '');
+};
 
+EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProcessString(content, relativePath) {
+  return md5Hex([content, relativePath, stringify(this.options, {
+    replacer(key, value) {
+      if (typeof value === 'function') {
+        return value.toString();
+      }
+      return value;
+    }
+  })]);
+};
+
+EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content
   const configPath = path.join(this.eslintrc, relativePath);
   const output = this.cli.executeOnText(content, configPath);
   const filteredOutput = filterAllIgnoredFileMessages(output);
-
-  // if verification has result
-  if (filteredOutput.results.length &&
-      filteredOutput.results[0].messages.length) {
-
-    // log formatter output
-    console.log(this.formatter(filteredOutput.results));
-
-    if (getResultSeverity(filteredOutput.results) > 0) {
-      if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
-        // throw error if severe messages exist
-        throw new Error('severe rule errors');
-      }
-    }
-  }
+  const toCache = {
+    lint: output,
+    output: content
+  };
 
   if (this.testGenerator) {
     let messages = [];
@@ -153,9 +165,32 @@ EslintValidationFilter.prototype.processString = function processString(content,
       messages = filteredOutput.results[0].messages || [];
     }
 
-    return this.testGenerator(relativePath, messages);
+    toCache.output = this.testGenerator(relativePath, messages);
   }
 
-  // return unmodified string
-  return content;
+  return toCache;
+};
+
+EslintValidationFilter.prototype.postProcess = function postProcess(fromCache) {
+  const lint = fromCache.lint;
+  const output = fromCache.output;
+
+  // if verification has result
+  if (lint.results.length &&
+      lint.results[0].messages.length) {
+
+    // log formatter output
+    console.log(this.formatter(lint.results));
+
+    if (getResultSeverity(lint.results) > 0) {
+      if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
+        // throw error if severe messages exist
+        throw new Error('severe rule errors');
+      }
+    }
+  }
+
+  return {
+    output
+  };
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepublish": "npm run babelify",
     "lint": "eslint .",
     "babelify-tests": "babel test --ignore fixture --out-dir build/test",
-    "test": "npm run babelify && npm run babelify-tests && npm run lint && node_modules/mocha/bin/mocha build/test/test.js"
+    "test": "npm run babelify && npm run babelify-tests && npm run lint && node_modules/mocha/bin/mocha build/test/common.js build/test/test.js"
   },
   "repository": {
     "type": "git",
@@ -38,8 +38,10 @@
   },
   "homepage": "https://github.com/jonathanKingston/broccoli-lint-eslint",
   "dependencies": {
-    "broccoli-filter": "^1.2.3",
-    "eslint": "^2.4.0"
+    "broccoli-persistent-filter": "^1.2.0",
+    "eslint": "^2.4.0",
+    "json-stable-stringify": "^1.0.1",
+    "md5-hex": "^1.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
@@ -52,6 +54,8 @@
     "chai": "^3.5.0",
     "eslint-config-nightmare-mode": "^2.3.0",
     "mocha": "^2.2.4",
-    "rimraf": "^2.5.1"
+    "rimraf": "^2.5.1",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,12 @@
 {
   "env": {
     "mocha": true
+  },
+  "globals": {
+    "chai": false,
+    "expect": false
+  },
+  "rules": {
+    "no-invalid-this": 0
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-invalid-this, newline-after-var */
+
+global.chai = require('chai');
+global.expect = chai.expect;
+const sinon = require('sinon');
+
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+
+beforeEach(function beforeEachAndEvery() {
+  this.sinon = sinon.sandbox.create();
+});
+
+afterEach(function afterEachAndEvery() {
+  this.sinon.restore();
+});


### PR DESCRIPTION
Hot on the heels of #14, here are the changes to use broccoli-persistent-filter. I've set it up to persist by default. It can be overridden by passing `{ persist: false }` as an option.

~~Tests are passing: https://travis-ci.org/nickiaconis/broccoli-eslinter/builds/115196276~~
**Edit:** This repo now leverages its own CI testing.