### PR TITLE
Update to eslint 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# develop
-- Update to eslint@2.2.0
+# 2.1.0 / 2016-03-20
+- Updated and pinned to eslint@2.4.0.
+- Begin tracking dates in CHANGELOG 😃
 
 # 1.1.1
 - Update to eslint@1.4.1
@@ -27,4 +28,4 @@
 
 - Removing default eslint.json which allows for ESLint to lookup .eslintrc
 - Updating .eslintrc
-- Fixing rules path to use `rulePaths` 
+- Fixing rules path to use `rulePaths`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-lint-eslint",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "broccoli filter that runs eslint",
   "main": "build/index.js",
   "scripts": {
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/jonathanKingston/broccoli-lint-eslint",
   "dependencies": {
     "broccoli-filter": "^1.2.3",
-    "eslint": "^2.3.0"
+    "eslint": "2.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/jonathanKingston/broccoli-lint-eslint",
   "dependencies": {
     "broccoli-filter": "^1.2.3",
-    "eslint": "2.4.0"
+    "eslint": "^2.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",


### PR DESCRIPTION
This PR updates our `package.json`'s eslint version to 2.4.0 and bumps the project version to `2.1.0`.

Users would have received 2.4.0 regardless since we had the `^` ahead of `2.3.0`, but I think it would be good to be more explicit about the version we're relying on after the... minor... set of issues that 2.3.0 led to. 

Furthermore, getting the package.json version bumped alongside this change seems like it makes for a good starting point from which to being addressing future outstanding issues with the current setup. (https://github.com/jonathanKingston/broccoli-lint-eslint/issues/26 seems like a good candidate -- I haven't taken a deep look into it yet -- and it would also be nice to close https://github.com/jonathanKingston/broccoli-lint-eslint/issues/23 with a link back to here.)

Finally, I noticed that our `CHANGELOG.md` could use a bit of love. I made a note for the latest changes, and also began tracking dates alongside the version number. 