### PR TITLE
Feature/update ignore filter message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,12 @@ function EslintValidationFilter(inputTree, options) {
   }
   this.options = options || {};
   this.eslintOptions = options.options || {};
+
+  // default ignore:true option
+  if (typeof this.eslintOptions.ignore === 'undefined') {
+    this.eslintOptions.ignore = true;
+  }
+
   // call base class constructor
   Filter.call(this, inputTree);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function getResultSeverity(result) {
  * @returns {Array} filtered errors
  */
 function filterIgnoredFileMessages(errors) {
-  const ignoreRegex = /File ignored because of your \.eslintignore file/;
+  const ignoreRegex = /File ignored because of a matching ignore pattern\. Use --no-ignore to override\./;
 
   return errors.filter((error) => {
     if (error.message.match(ignoreRegex)) {
@@ -77,7 +77,7 @@ function EslintValidationFilter(inputTree, options) {
 
   this.cli = new CLIEngine(this.eslintOptions);
 
-  this.eslintrc = inputTree;
+  this.inputTree = inputTree;
 
   this.testGenerator = options.testGenerator;
   if (this.testGenerator) {
@@ -90,6 +90,16 @@ EslintValidationFilter.prototype = Object.create(Filter.prototype);
 EslintValidationFilter.prototype.constructor = EslintValidationFilter;
 EslintValidationFilter.prototype.extensions = ['js'];
 EslintValidationFilter.prototype.targetExtension = 'js';
+
+EslintValidationFilter.prototype.write = function write(readTree, destDir) {
+  return readTree(this.inputTree).then((srcDir) => {
+    if (!this.eslintrc) {
+      this.eslintrc = srcDir;
+    }
+
+    return Filter.prototype.write.call(this, readTree, destDir);
+  });
+};
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   'use strict'; // eslint-disable-line strict

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,10 +51,11 @@ function filterIgnoredFileMessages(errors) {
 function filterAllIgnoredFileMessages(result) {
   const resultOutput = result;
 
-  result.results.map((resultItem) => {
+  result.results.forEach((resultItem) => {
     resultItem.messages = filterIgnoredFileMessages(resultItem.messages);
     return resultItem;
   });
+
   return resultOutput;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,6 @@ function filterAllIgnoredFileMessages(result) {
 
   result.results.forEach((resultItem) => {
     resultItem.messages = filterIgnoredFileMessages(resultItem.messages);
-    return resultItem;
   });
 
   return resultOutput;

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ function EslintValidationFilter(inputTree, options) {
 
   this.cli = new CLIEngine(this.eslintOptions);
 
-  this.inputTree = inputTree;
+  this.eslintrc = inputTree;
 
   this.testGenerator = options.testGenerator;
   if (this.testGenerator) {
@@ -90,16 +90,6 @@ EslintValidationFilter.prototype = Object.create(Filter.prototype);
 EslintValidationFilter.prototype.constructor = EslintValidationFilter;
 EslintValidationFilter.prototype.extensions = ['js'];
 EslintValidationFilter.prototype.targetExtension = 'js';
-
-EslintValidationFilter.prototype.write = function write(readTree, destDir) {
-  return readTree(this.inputTree).then((srcDir) => {
-    if (!this.eslintrc) {
-      this.eslintrc = srcDir;
-    }
-
-    return Filter.prototype.write.call(this, readTree, destDir);
-  });
-};
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   'use strict'; // eslint-disable-line strict

--- a/test/fixture/.eslintignore
+++ b/test/fixture/.eslintignore
@@ -1,0 +1,7 @@
+# avoid this files to be ignored
+!1.js
+!2.js
+!3.js
+
+# ignoring a target file
+4.js

--- a/test/fixture/4.js
+++ b/test/fixture/4.js
@@ -1,0 +1,1 @@
+alert('This file will be ignored.');

--- a/test/helpers/run-eslint.js
+++ b/test/helpers/run-eslint.js
@@ -16,7 +16,6 @@ module.exports = function runEslint(path, _options) {
   // default options
   options.format = options.format || 'eslint/lib/formatters/compact';
   options.options = options.options || {};
-  options.options.ignore = options.options.ignore || false;
 
   const tree = eslint(path, options);
   const builder = new broccoli.Builder(tree);

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const expect = require('chai').expect;
 const runEslint = require('./helpers/run-eslint');
 const FIXTURES = 'test/fixture';
@@ -7,11 +8,16 @@ const CONSOLE = '(no-console)';
 const CUSTOM_RULES = 'testing custom rules';
 const DOUBLEQUOTE = 'Strings must use doublequote.';
 const FILEPATH = 'fixture/1.js';
+const TEST_IGNORE_PATH = path.resolve(process.cwd(), './test/fixture/.eslintignore');
 
 describe('EslintValidationFilter', function describeEslintValidationFilter() {
   it('should report errors', function shouldReportErrors() {
     // lint test fixtures
-    const promise = runEslint(FIXTURES);
+    const promise = runEslint(FIXTURES, {
+      options: {
+        ignore: false
+      }
+    });
 
     return promise.then(function assertLinting({buildLog}) {
       expect(buildLog, 'Used eslint validation').to.have.string(CAMELCASE);
@@ -26,6 +32,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     // lint test fixtures using a custom rule
     const promise = runEslint(FIXTURES, {
       options: {
+        ignore: false,
         rulePaths: ['conf/rules'],
         rules: {
           'custom-no-alert': 2
@@ -38,10 +45,40 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     });
   });
 
+  it('should use a default ignore:true option', function shouldAcceptDefaultIgnore() {
+    const promise = runEslint(FIXTURES, {
+      options: {
+        ignorePath: TEST_IGNORE_PATH
+      }
+    });
+
+    return promise
+      .then(function assertLinting({buildLog}) {
+        expect(buildLog)
+        .to.not.match(/File ignored because of a matching ignore pattern\. Use --no-ignore to override\./);
+      });
+  });
+
+  it('should accept an ignore option', function shouldAcceptIgnoreOption() {
+    const promise = runEslint(FIXTURES, {
+      options: {
+        ignore: true,
+        ignorePath: TEST_IGNORE_PATH
+      }
+    });
+
+    return promise
+      .then(function assertLinting({buildLog}) {
+        expect(buildLog)
+        .to.not.match(/File ignored because of a matching ignore pattern\. Use --no-ignore to override\./);
+      });
+  });
+
   it('should accept config file path', function shouldAcceptConfigFile() {
     // lint test fixtures using a config file at a non-default path
     const promise = runEslint(FIXTURES, {
       options: {
+        ignore: false,
         configFile: 'conf/eslint.json'
       }
     });
@@ -54,6 +91,9 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
 
   it('should create test files', function shouldGenerateTests() {
     const promise = runEslint(FIXTURES, {
+      options: {
+        ignore: false
+      },
       testGenerator() {
         return 'test-content';
       }


### PR DESCRIPTION
When the **eslint@2** upgrade was made, the `filterIgnoredFileMessages` function was broken, since the new **eslint@2** [changed the message](https://github.com/eslint/eslint/blob/master/lib/cli-engine.js#L241) produced for the ignored files.

Maybe somehow related to the reported error on [ember-cli-eslint#44](https://github.com/jonathanKingston/ember-cli-eslint/issues/44).